### PR TITLE
Fix some typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Colored Comments
-The Colored Comments plugin was designed to help create more readible comments throughout your code. It was heavily inspired by [Better Comments by aaron-bond
+The Colored Comments plugin was designed to help create more readable comments throughout your code. It was heavily inspired by [Better Comments by aaron-bond
 ](https://github.com/aaron-bond/better-comments)
 
 # NOTICE !!
-If using the new verison run Generate/Regenerate Color Scheme
+If using the new version run Generate/Regenerate Color Scheme
 
 ## Global Settings
 The following are global settings for ColoredComments
@@ -21,7 +21,7 @@ The following are global settings for ColoredComments
 <img width="461" alt="2020-03-06_21-11-38" src="https://user-images.githubusercontent.com/32599364/76134801-30df8980-5fef-11ea-92b2-ae7155af956b.png">
 
 
-### Version > 2
+### Version < 2
 <img width="518" alt="2020-02-21_08-52-51" src="https://user-images.githubusercontent.com/32599364/75039960-c4f61080-5487-11ea-9a43-f9ea7a53842e.png">
 
 
@@ -31,8 +31,8 @@ Add new tags easily with the following format. Keep in mind the following:
 - **identifiers**: These can be _plaintext_ or _regex_ patterns. If they are _regex_ be sure to set the _is_regex_ property to `true`
 - **is_regex**: Set this to `true` if your identifier is a _regex_
 - **priority**: This setting is critical if you want to prioritize tag settings. **Default**: 2147483647
-    - This should be used if there are multiple tags that could match on the same thing. An example of this would be `"identifier": "*"` and `"identifier": "[\\*]?[ ]?@param"` could both match on `* @param` because one is less precise. To avoid these conflicts you can give the `[\\*]?[ ]?@param` a higher priority such as `"-1"`, Negative values get higher priorty than positive values. If two or more tags get the same priority, they are treated as first come first serve type of matching.
-- **Scope**: Are built in colors from your current theme. **_Scope takes precendence over Color_**
+    - This should be used if there are multiple tags that could match on the same thing. An example of this would be `"identifier": "*"` and `"identifier": "[\\*]?[ ]?@param"` could both match on `* @param` because one is less precise. To avoid these conflicts you can give the `[\\*]?[ ]?@param` a higher priority such as `"-1"`, Negative values get higher priority than positive values. If two or more tags get the same priority, they are treated as first come first serve type of matching.
+- **Scope**: Are built in colors from your current theme. **_Scope takes precedence over Color_**
 - **underline**: Sublime API setting for region draws
 - **stippled_underline**: Sublime API setting for region draws
 - **squiggly_underline**: Sublime API setting for region draws


### PR DESCRIPTION
Hi @TheSecEng,

just fixed a few typos in the Readme file I stumbled upon. 
The only change worth mentioning is the "> 2" vs "< 2" - I hope my brain didn't knot in the wrong way here ;)

Cheers and as always thanks for this beautiful plugin!