### PR TITLE
Fix/continued highlighting

### DIFF
--- a/colored_comments.py
+++ b/colored_comments.py
@@ -71,7 +71,8 @@ class ColoredCommentsCommand(sublime_plugin.TextCommand):
         for region in self.regions:
             for reg in self.view.split_by_newlines(region):
                 line = self.view.substr(reg)
-                line = line[1:] if line.startswith(" ") else line
+                if not continued_matching_pattern.startswith(" "):
+                    line = line.strip()
                 for tag_identifier in self.tag_regex:
                     matches = self.tag_regex[tag_identifier].search(
                         self.view.substr(reg).strip()

--- a/colored_comments.py
+++ b/colored_comments.py
@@ -70,7 +70,8 @@ class ColoredCommentsCommand(sublime_plugin.TextCommand):
         prev_match = str()
         for region in self.regions:
             for reg in self.view.split_by_newlines(region):
-                line = self.view.substr(reg)[1:]
+                line = self.view.substr(reg)
+                line = line[1:] if line.startswith(" ") else line
                 for tag_identifier in self.tag_regex:
                     matches = self.tag_regex[tag_identifier].search(
                         self.view.substr(reg).strip()
@@ -205,7 +206,8 @@ def _get_icon():
             icon = "%s/%s.png" % (icon_path, icon)
             sublime.load_binary_resource(icon)
         except OSError as ex:
-            log.debug("[Colored Comments]: {} - {}".format(_get_icon.__name__, ex))
+            log.debug(
+                "[Colored Comments]: {} - {}".format(_get_icon.__name__, ex))
             icon = str()
             pass
     return icon
@@ -216,7 +218,8 @@ def load_settings():
     settings = sublime.load_settings(settings_path)
     tag_map = settings.get("tags", [])
     continued_matching = settings.get("continued_matching", False)
-    continued_matching_pattern = settings.get("continued_matching_pattern", "-")
+    continued_matching_pattern = settings.get(
+        "continued_matching_pattern", "-")
 
 
 def setup_logging():


### PR DESCRIPTION
Previously, continued matching would remove the first character of a line if that character was a space. Which in scenarios when you have a `continued_matching_pattern` like `-` then stripping the single space would only work like the following

```python
# TODO Working with single space strip
- asdasdasd
```

The below wouldn't work because we have multiple spaces.
```python
""" TODO Comments
      - Not working
"""
```

Now if the `continued_matching_pattern` doesn't start with a space, we strip all whitespace from the comment line first.